### PR TITLE
Value highlighting (works for single-line values so far)

### DIFF
--- a/splunk-conf.json
+++ b/splunk-conf.json
@@ -32,7 +32,7 @@
         },
         {
             "comment": "Setting (can be multiline). Begins with 'key=', ends with newline without backslash",
-            "begin":"^[\\t ]*([A-z0-9.$*:\\/\\\\]+)[\\t ]*(=)[\\t ]*",
+            "begin": "^[ \\t]*([^\\n\\r ]+)[ \\t]*(=)",
             "beginCaptures": {
                 "1": {
                     "name": "support.function"
@@ -41,7 +41,20 @@
                     "name": "keyword.operator"
                 }
             },
-            "end":"(([^\\\\]\\r?\\n$)|(\\\\\\r?\\n$))",
+            "end":"[ \\t]*([^\\n\\r]+[^\\\\]|[^\\n\\r]+\\\\(\\r?\\n[ \\t]*[^\\n\\r]*\\\\?)*)\\r?\\n",
+            // TODO: break this up into intentionally matching several groups
+            // ie: 1 group just for the first line, etc.
+            "endCaptures": {
+                "1": {
+                    "name": "constant.character"
+                },
+                "2": {
+                    "name": "entity.name.function"
+                },
+                "3": {
+                    "name": "keyword.operator"
+                }
+            },
             "name": "splunk.conf.setting"
         }
     ]

--- a/splunk-conf.tmLanguage
+++ b/splunk-conf.tmLanguage
@@ -43,7 +43,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^[\t ]*([A-z0-9.$*:\/\\]+)[\t ]*(=)[\t ]*</string>
+			<string>^[ \t]*([^\n\r ]+)[ \t]*(=)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -60,7 +60,25 @@
 			<key>comment</key>
 			<string>Setting (can be multiline). Begins with 'key=', ends with newline without backslash</string>
 			<key>end</key>
-			<string>(([^\\]\r?\n$)|(\\\r?\n$))</string>
+			<string>[ \t]*([^\n\r]+[^\\]|[^\n\r]+\\(\r?\n[ \t]*[^\n\r]*\\?)*)\r?\n</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>constant.character</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>splunk.conf.setting</string>
 		</dict>


### PR DESCRIPTION
The regex pattern actually matches mutli-line values,
but I think Sublime Text is doing some optimization
to prevent performance issues.

Eventually closes #15 

[Regex diagram](https://regexper.com/#%5B%20%5Ct%5D*%28%5B%5E%5Cn%5Cr%5D%2B%5B%5E%5C%5C%5D%7C%5B%5E%5Cn%5Cr%5D%2B%5C%5C%28%5Cr%3F%5Cn%5B%20%5Ct%5D*%5B%5E%5Cn%5Cr%5D*%5C%5C%3F%29*%29%2B%5Cr%3F%5Cn)

TODO:
- [ ] re-write the regex, possibly using additional rules ie: single line value, multi-line value, and maybe even continuation of a multiline value
- [ ] clean up the `endCaptures` list
- [ ] remove TODOs from the JSON file since that's breaking the test runner

Here's what the test conf file looks like:
![capturfiles_3](https://cloud.githubusercontent.com/assets/1480063/17356890/cc077b3e-590e-11e6-964e-54be82e64dd8.png)
